### PR TITLE
Add exam security controls

### DIFF
--- a/backend/app/extensions/db.py
+++ b/backend/app/extensions/db.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 
 from sqlalchemy import create_engine
+from sqlalchemy import inspect, text
 from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
@@ -29,6 +30,7 @@ def init_db() -> None:
     from app.utils.security import hash_password
 
     Base.metadata.create_all(bind=engine)
+    ensure_exam_security_columns()
 
     with SessionLocal() as db:
         if not settings.initial_admin_username:
@@ -54,3 +56,23 @@ def init_db() -> None:
             )
         )
         db.commit()
+
+
+def ensure_exam_security_columns() -> None:
+    inspector = inspect(engine)
+    if not inspector.has_table("portal_exams"):
+        return
+
+    existing_columns = {column["name"] for column in inspector.get_columns("portal_exams")}
+    security_columns = {
+        "block_clipboard": "BOOLEAN NOT NULL DEFAULT TRUE",
+        "block_context_menu": "BOOLEAN NOT NULL DEFAULT TRUE",
+        "block_inspect_shortcuts": "BOOLEAN NOT NULL DEFAULT TRUE",
+        "enforce_fullscreen": "BOOLEAN NOT NULL DEFAULT FALSE",
+        "track_focus_loss": "BOOLEAN NOT NULL DEFAULT TRUE",
+    }
+    with engine.begin() as connection:
+        for column_name, definition in security_columns.items():
+            if column_name in existing_columns:
+                continue
+            connection.execute(text(f"ALTER TABLE portal_exams ADD COLUMN {column_name} {definition}"))

--- a/backend/app/models/exam.py
+++ b/backend/app/models/exam.py
@@ -20,6 +20,11 @@ class Exam(Base):
     description: Mapped[str] = mapped_column(Text, nullable=False)
     duration_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    block_clipboard: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    block_context_menu: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    block_inspect_shortcuts: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    enforce_fullscreen: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    track_focus_loss: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     created_by_id: Mapped[int | None] = mapped_column(ForeignKey("portal_users.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -93,6 +98,11 @@ class ExamAttempt(Base):
     assignment = relationship("ExamAssignment", back_populates="attempts")
     student = relationship("User", back_populates="attempts")
     answers = relationship("AttemptAnswer", back_populates="attempt", cascade="all, delete-orphan")
+    security_incidents = relationship(
+        "SecurityIncident",
+        back_populates="attempt",
+        cascade="all, delete-orphan",
+    )
 
 
 class AttemptAnswer(Base):
@@ -107,3 +117,23 @@ class AttemptAnswer(Base):
 
     attempt = relationship("ExamAttempt", back_populates="answers")
     question = relationship("ExamQuestion", back_populates="answers")
+
+
+class SecurityIncident(Base):
+    __tablename__ = "security_incidents"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    attempt_id: Mapped[int] = mapped_column(ForeignKey("exam_attempts.id", ondelete="CASCADE"), index=True)
+    student_id: Mapped[int] = mapped_column(ForeignKey("portal_users.id", ondelete="CASCADE"), index=True)
+    exam_id: Mapped[int] = mapped_column(ForeignKey("portal_exams.id", ondelete="CASCADE"), index=True)
+    incident_type: Mapped[str] = mapped_column(String(80), nullable=False)
+    detail: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    attempt = relationship("ExamAttempt", back_populates="security_incidents")
+    student = relationship("User")
+    exam = relationship("Exam")

--- a/backend/app/modules/admin/routes.py
+++ b/backend/app/modules/admin/routes.py
@@ -6,10 +6,18 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.extensions.db import get_db
 from app.extensions.mail import send_assignment_email
-from app.models.exam import AttemptStatus, Exam, ExamAssignment, ExamAttempt, ExamQuestion
+from app.models.exam import AttemptStatus, Exam, ExamAssignment, ExamAttempt, ExamQuestion, SecurityIncident
 from app.models.user import User, UserRole
 from app.modules.auth.dependencies import require_admin
-from app.schemas.exam import AssignmentCreate, AssignmentRead, BulkExamCreate, DashboardStats, ExamCreate, ExamRead
+from app.schemas.exam import (
+    AssignmentCreate,
+    AssignmentRead,
+    BulkExamCreate,
+    DashboardStats,
+    ExamCreate,
+    ExamRead,
+    SecurityIncidentRead,
+)
 from app.schemas.user import BulkUserCreate, UserCreate, UserRead
 from app.utils.security import hash_password
 
@@ -154,6 +162,11 @@ def create_exam(
         title=payload.title,
         description=payload.description,
         duration_minutes=payload.duration_minutes,
+        block_clipboard=payload.block_clipboard,
+        block_context_menu=payload.block_context_menu,
+        block_inspect_shortcuts=payload.block_inspect_shortcuts,
+        enforce_fullscreen=payload.enforce_fullscreen,
+        track_focus_loss=payload.track_focus_loss,
         created_by_id=current_user.id,
         questions=[ExamQuestion(**question.model_dump()) for question in payload.questions],
     )
@@ -174,6 +187,11 @@ def create_exams_bulk(
             title=exam.title,
             description=exam.description,
             duration_minutes=exam.duration_minutes,
+            block_clipboard=exam.block_clipboard,
+            block_context_menu=exam.block_context_menu,
+            block_inspect_shortcuts=exam.block_inspect_shortcuts,
+            enforce_fullscreen=exam.enforce_fullscreen,
+            track_focus_loss=exam.track_focus_loss,
             created_by_id=current_user.id,
             questions=[ExamQuestion(**question.model_dump()) for question in exam.questions],
         )
@@ -265,3 +283,31 @@ def list_assignments(
             )
         )
     return result
+
+
+@router.get("/security-incidents", response_model=list[SecurityIncidentRead])
+def list_security_incidents(
+    _: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> list[SecurityIncidentRead]:
+    incidents = db.scalars(
+        select(SecurityIncident)
+        .options(selectinload(SecurityIncident.student), selectinload(SecurityIncident.exam))
+        .order_by(desc(SecurityIncident.occurred_at), desc(SecurityIncident.id))
+        .limit(100)
+    ).all()
+
+    return [
+        SecurityIncidentRead(
+            id=incident.id,
+            attempt_id=incident.attempt_id,
+            student_id=incident.student_id,
+            exam_id=incident.exam_id,
+            incident_type=incident.incident_type,
+            detail=incident.detail,
+            occurred_at=incident.occurred_at,
+            student_name=incident.student.full_name if incident.student else None,
+            exam_title=incident.exam.title if incident.exam else None,
+        )
+        for incident in incidents
+    ]

--- a/backend/app/modules/student/routes.py
+++ b/backend/app/modules/student/routes.py
@@ -5,7 +5,7 @@ from sqlalchemy import desc, func, select
 from sqlalchemy.orm import Session, selectinload
 
 from app.extensions.db import get_db
-from app.models.exam import AttemptAnswer, AttemptStatus, Exam, ExamAssignment, ExamAttempt
+from app.models.exam import AttemptAnswer, AttemptStatus, Exam, ExamAssignment, ExamAttempt, SecurityIncident
 from app.models.user import User
 from app.modules.auth.dependencies import require_student
 from app.schemas.exam import (
@@ -16,6 +16,8 @@ from app.schemas.exam import (
     AttemptSubmitRequest,
     ExamStartResponse,
     QuestionRead,
+    SecurityIncidentCreate,
+    SecurityIncidentRead,
     StudentDashboard,
 )
 
@@ -149,11 +151,61 @@ def start_exam(
         title=assignment.exam.title,
         description=assignment.exam.description,
         duration_minutes=assignment.exam.duration_minutes,
+        block_clipboard=assignment.exam.block_clipboard,
+        block_context_menu=assignment.exam.block_context_menu,
+        block_inspect_shortcuts=assignment.exam.block_inspect_shortcuts,
+        enforce_fullscreen=assignment.exam.enforce_fullscreen,
+        track_focus_loss=assignment.exam.track_focus_loss,
         started_at=attempt.started_at,
         question_count=len(assignment.exam.questions),
         current_question_index=next_unanswered_index,
         saved_answers=saved_answers,
         questions=[QuestionRead.model_validate(question) for question in assignment.exam.questions],
+    )
+
+
+@router.post(
+    "/attempts/{attempt_id}/security-incidents",
+    response_model=SecurityIncidentRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def log_security_incident(
+    attempt_id: int,
+    payload: SecurityIncidentCreate,
+    current_user: User = Depends(require_student),
+    db: Session = Depends(get_db),
+) -> SecurityIncidentRead:
+    attempt = db.scalar(
+        select(ExamAttempt)
+        .where(ExamAttempt.id == attempt_id, ExamAttempt.student_id == current_user.id)
+        .options(selectinload(ExamAttempt.assignment).selectinload(ExamAssignment.exam))
+    )
+    if attempt is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attempt not found")
+    if attempt.status == AttemptStatus.submitted:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Attempt already submitted")
+
+    incident = SecurityIncident(
+        attempt_id=attempt.id,
+        student_id=current_user.id,
+        exam_id=attempt.assignment.exam.id,
+        incident_type=payload.incident_type,
+        detail=payload.detail,
+    )
+    db.add(incident)
+    db.commit()
+    db.refresh(incident)
+
+    return SecurityIncidentRead(
+        id=incident.id,
+        attempt_id=incident.attempt_id,
+        student_id=incident.student_id,
+        exam_id=incident.exam_id,
+        incident_type=incident.incident_type,
+        detail=incident.detail,
+        occurred_at=incident.occurred_at,
+        student_name=current_user.full_name,
+        exam_title=attempt.assignment.exam.title,
     )
 
 

--- a/backend/app/schemas/exam.py
+++ b/backend/app/schemas/exam.py
@@ -35,6 +35,11 @@ class ExamCreate(BaseModel):
     title: str = Field(min_length=3, max_length=180)
     description: str = Field(min_length=5)
     duration_minutes: int = Field(gt=0, le=600)
+    block_clipboard: bool = True
+    block_context_menu: bool = True
+    block_inspect_shortcuts: bool = True
+    enforce_fullscreen: bool = False
+    track_focus_loss: bool = True
     questions: list[QuestionCreate] = Field(min_length=1)
 
 
@@ -48,6 +53,11 @@ class ExamRead(BaseModel):
     description: str
     duration_minutes: int
     is_active: bool
+    block_clipboard: bool
+    block_context_menu: bool
+    block_inspect_shortcuts: bool
+    enforce_fullscreen: bool
+    track_focus_loss: bool
     created_at: datetime
     questions: list[AdminQuestionRead] = []
 
@@ -103,6 +113,11 @@ class ExamStartResponse(BaseModel):
     title: str
     description: str
     duration_minutes: int
+    block_clipboard: bool
+    block_context_menu: bool
+    block_inspect_shortcuts: bool
+    enforce_fullscreen: bool
+    track_focus_loss: bool
     started_at: datetime
     question_count: int
     current_question_index: int
@@ -122,6 +137,25 @@ class AttemptResult(BaseModel):
     percentage: float
     status: AttemptStatus
     submitted_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SecurityIncidentCreate(BaseModel):
+    incident_type: str = Field(min_length=3, max_length=80)
+    detail: str = Field(default="", max_length=1000)
+
+
+class SecurityIncidentRead(BaseModel):
+    id: int
+    attempt_id: int
+    student_id: int
+    exam_id: int
+    incident_type: str
+    detail: str
+    occurred_at: datetime
+    student_name: str | None = None
+    exam_title: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,108 +1,227 @@
+:root {
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --surface-muted: #f0f4f8;
+  --text: #101828;
+  --muted: #667085;
+  --line: #d9e2ec;
+  --primary: #2154d9;
+  --primary-dark: #163b99;
+  --success: #16855f;
+  --info: #0876a6;
+  --warning: #b86912;
+  --danger: #c73232;
+  --shadow-sm: 0 10px 28px rgba(16, 24, 40, 0.08);
+  --shadow-md: 0 20px 60px rgba(16, 24, 40, 0.12);
+  --radius: 8px;
+}
+
 .login-shell {
   min-height: 100vh;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(360px, 0.95fr) minmax(360px, 520px);
+  gap: 40px;
   align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, #dbeafe, #f8fafc);
-  padding: 24px;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(33, 84, 217, 0.12), transparent 32%),
+    linear-gradient(135deg, #eef4ff 0%, #f8fafc 48%, #f3fbf7 100%);
+  color: var(--text);
+  padding: 48px clamp(24px, 6vw, 88px);
+}
+
+.login-hero {
+  min-height: 560px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  border: 1px solid rgba(33, 84, 217, 0.18);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(rgba(8, 19, 45, 0.24), rgba(8, 19, 45, 0.74)),
+    url('https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1400&q=80')
+      center/cover;
+  box-shadow: var(--shadow-md);
+  padding: clamp(28px, 4vw, 48px);
+  overflow: hidden;
+}
+
+.hero-kicker,
+.prototype-chip,
+.timer-pill {
+  width: fit-content;
+  border-radius: 999px;
+}
+
+.hero-kicker {
+  background: rgba(255, 255, 255, 0.16);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  padding: 8px 12px;
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.login-hero h1 {
+  max-width: 660px;
+  margin: 20px 0 12px;
+  color: #ffffff;
+  font-size: clamp(2.35rem, 5vw, 4.8rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+.login-hero p {
+  max-width: 560px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 1.06rem;
+}
+
+.hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.hero-stats span {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 9px 12px;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.login-card,
+.white-panel {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(217, 226, 236, 0.9);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
 }
 
 .login-card {
-  width: min(540px, 100%);
-  background: #fff;
-  border-radius: 24px;
-  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.12);
-  padding: 44px;
+  width: 100%;
+  padding: clamp(28px, 4vw, 44px);
+  backdrop-filter: blur(14px);
+}
+
+.brand-mark,
+.brand-area {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 900;
+  color: var(--text);
 }
 
 .brand-mark {
-  font-size: 1.5rem;
-  font-weight: 800;
-  color: #2563eb;
+  font-size: 1.16rem;
+}
+
+.brand-icon {
+  display: inline-grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 8px;
+  background: #102a56;
+  color: #ffffff;
+  font-weight: 900;
+  box-shadow: inset 0 -8px 18px rgba(255, 255, 255, 0.12);
 }
 
 .auth-tab-row {
-  display: flex;
-  gap: 10px;
-  margin: 24px 0;
-  padding: 8px;
-  background: #eff6ff;
-  border-radius: 14px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin: 28px 0;
+  padding: 6px;
+  background: #edf2f7;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--radius);
 }
 
-.auth-tab {
-  flex: 1;
-  border: 0;
-  border-radius: 10px;
-  padding: 12px 16px;
-  background: transparent;
-  font-weight: 700;
-  color: #475569;
-  cursor: pointer;
-}
-
-.auth-tab.active {
-  background: #fff;
-  color: #1d4ed8;
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.12);
-}
-
-.portal-page {
-  min-height: 100vh;
-  background: #f5f7fb;
-  color: #1f2937;
-}
-
-.portal-navbar {
-  background: linear-gradient(90deg, #346ee4, #5ac28f);
-  color: #fff;
-  padding: 18px 5vw;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  box-shadow: 0 6px 24px rgba(52, 110, 228, 0.24);
-  position: sticky;
-  top: 0;
-  z-index: 20;
-}
-
-.brand-area {
-  font-size: 1.25rem;
-  font-weight: 800;
-}
-
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: 24px;
-}
-
+.auth-tab,
 .nav-links button,
 .logout-btn,
 .action-btn,
 .mini-btn {
   border: 0;
   cursor: pointer;
-  font-weight: 700;
+  font-weight: 800;
   font-family: inherit;
 }
 
-.nav-links button {
+.auth-tab {
+  min-height: 44px;
+  border-radius: 7px;
   background: transparent;
-  color: rgba(255, 255, 255, 0.92);
-  font-size: 1rem;
+  color: #475467;
 }
 
+.auth-tab.active {
+  background: #ffffff;
+  color: var(--primary);
+  box-shadow: 0 8px 18px rgba(16, 24, 40, 0.08);
+}
+
+.portal-page {
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, #eef4ff 0, rgba(246, 248, 251, 0) 320px),
+    var(--bg);
+  color: var(--text);
+  padding-bottom: 56px;
+}
+
+.portal-navbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 5vw;
+  background: rgba(255, 255, 255, 0.86);
+  border-bottom: 1px solid rgba(217, 226, 236, 0.86);
+  backdrop-filter: blur(18px);
+}
+
+.brand-area {
+  font-size: 1.03rem;
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-links button,
+.logout-btn {
+  min-height: 40px;
+  border-radius: 7px;
+  padding: 10px 13px;
+  background: transparent;
+  color: #344054;
+}
+
+.nav-links button:hover,
 .nav-links .nav-active {
-  text-decoration: underline;
-  text-underline-offset: 8px;
+  background: #e9efff;
+  color: var(--primary-dark);
 }
 
 .logout-btn {
-  background: #ffffff;
-  color: #111827 !important;
-  padding: 10px 16px;
-  border-radius: 6px;
+  border: 1px solid #d0d5dd;
+  background: #ffffff !important;
+  color: #101828 !important;
 }
 
 .welcome-banner,
@@ -116,14 +235,19 @@
 }
 
 .welcome-banner {
-  margin-top: 24px;
-  padding: 34px 24px;
-  border-radius: 14px;
-  background: linear-gradient(90deg, #d9e3fb, #e5f1f6);
-  border: 1px solid #cddff8;
+  margin-top: 28px;
+  padding: clamp(24px, 4vw, 38px);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(120deg, rgba(16, 42, 86, 0.94), rgba(33, 84, 217, 0.84)),
+    url('https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?auto=format&fit=crop&w=1400&q=80')
+      center/cover;
+  color: #ffffff;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-end;
+  gap: 24px;
+  box-shadow: var(--shadow-md);
 }
 
 .welcome-banner h1,
@@ -131,79 +255,123 @@
 .white-panel h2,
 .metric-card h3 {
   margin: 0;
+  letter-spacing: 0;
+}
+
+.welcome-banner h1 {
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1.05;
 }
 
 .welcome-banner p,
+.login-card p {
+  margin: 10px 0 0;
+}
+
+.welcome-banner p {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 1.02rem;
+}
+
+.login-card h1 {
+  font-size: clamp(1.8rem, 3vw, 2.45rem);
+  line-height: 1.08;
+}
+
+.login-card p,
 .helper-text,
 .row-card p,
-.metric-card p,
-.login-card p {
-  margin: 8px 0 0;
-  color: #6b7280;
+.metric-card p {
+  color: var(--muted);
 }
 
 .prototype-chip {
-  font-weight: 600;
-  color: #374151;
+  flex: none;
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  color: #ffffff;
+  padding: 9px 13px;
+  font-weight: 800;
+  font-size: 0.88rem;
 }
 
 .metric-grid {
-  margin-top: 24px;
+  margin-top: 22px;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 16px;
+  gap: 14px;
 }
 
 .metric-card {
-  border-radius: 14px;
-  padding: 28px 20px;
-  color: #fff;
+  position: relative;
+  min-height: 142px;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: var(--radius);
+  padding: 22px;
+  color: #ffffff;
+  box-shadow: var(--shadow-sm);
 }
 
-.metric-card.blue { background: #4b82f4; }
-.metric-card.green { background: #4ca05b; }
-.metric-card.cyan { background: #4fb7d5; }
-.metric-card.orange { background: #eeaa37; }
+.metric-card::before {
+  content: '';
+  position: absolute;
+  inset: auto -28px -42px auto;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.metric-card.blue { background: #2154d9; }
+.metric-card.green { background: #16855f; }
+.metric-card.cyan { background: #0876a6; }
+.metric-card.orange { background: #b86912; }
 
 .metric-card h3 {
-  font-size: 2rem;
+  position: relative;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1;
 }
 
 .metric-card p {
-  color: #fff;
-  font-weight: 600;
+  position: relative;
+  margin: 8px 0 0;
+  color: rgba(255, 255, 255, 0.86);
+  font-weight: 800;
 }
 
 .metric-icon {
-  background: rgba(255, 255, 255, 0.16);
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+  position: relative;
   display: grid;
+  width: 46px;
+  height: 46px;
   place-items: center;
-  font-size: 1.4rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.16);
+  font-size: 1.35rem;
 }
 
 .notice-bar {
   margin-top: 18px;
-  background: #eff6ff;
-  color: #1d4ed8;
-  border: 1px solid #bfdbfe;
-  border-radius: 14px;
-  padding: 14px 18px;
-  font-weight: 600;
+  background: #fff7ed;
+  color: #9a3412;
+  border: 1px solid #fed7aa;
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  font-weight: 800;
 }
 
 .white-panel {
   margin-top: 24px;
-  background: #fff;
-  border-radius: 14px;
-  padding: 22px;
-  box-shadow: 0 10px 32px rgba(15, 23, 42, 0.08);
+  padding: clamp(18px, 2.4vw, 26px);
+}
+
+.white-panel h2 {
+  font-size: 1.18rem;
 }
 
 .quick-grid,
@@ -222,35 +390,59 @@
 .three-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   margin-top: 24px;
-  padding-bottom: 48px;
 }
 
 .two-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   margin-top: 24px;
-  padding-bottom: 48px;
   align-items: start;
 }
 
 .action-btn,
 .mini-btn {
-  border-radius: 12px;
-  padding: 16px 18px;
+  min-height: 46px;
+  border-radius: 7px;
+  padding: 13px 16px;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    filter 160ms ease;
+}
+
+.action-btn:hover,
+.mini-btn:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.02);
+}
+
+.action-btn:disabled,
+.mini-btn:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .action-btn.blue,
-.mini-btn { background: #356cf6; color: #fff; }
-.action-btn.green { background: #438f59; color: #fff; }
-.action-btn.cyan { background: #57c2ea; color: #fff; }
-.action-btn.yellow { background: #f7c340; color: #111827; }
+.mini-btn {
+  background: var(--primary);
+  color: #ffffff;
+}
+
+.action-btn.green { background: var(--success); color: #ffffff; }
+.action-btn.cyan { background: var(--info); color: #ffffff; }
+.action-btn.yellow { background: #f5b84b; color: #271700; }
 
 .compact-btn {
-  width: 120px;
-  padding: 12px 16px;
+  width: 124px;
+  padding-inline: 12px;
 }
 
 .mini-card {
   margin: 0;
+}
+
+.mini-card .mini-btn {
+  margin-top: 18px;
 }
 
 .form-stack,
@@ -265,39 +457,56 @@ input,
 select,
 textarea {
   width: 100%;
-  border: 1px solid #d1d5db;
-  border-radius: 12px;
-  padding: 14px 16px;
-  font: inherit;
-  color: #111827;
-  background: #fff;
+  border: 1px solid #ccd6e0;
+  border-radius: 7px;
+  padding: 13px 14px;
+  color: var(--text);
+  background: #ffffff;
+  outline: none;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease;
 }
 
 textarea {
+  min-height: 120px;
   resize: vertical;
+  line-height: 1.5;
+}
+
+input:focus,
+select:focus,
+textarea:focus,
+button:focus-visible {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(33, 84, 217, 0.13);
 }
 
 .alert-message {
-  color: #dc2626;
-  font-weight: 600;
+  margin: 0;
+  color: var(--danger) !important;
+  font-weight: 800;
 }
 
 .google-login-wrap {
-  margin-top: 18px;
   display: flex;
   justify-content: center;
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
 }
 
 .google-disabled {
   margin: 0;
   font-size: 0.9rem;
-  color: #64748b;
+  color: var(--muted);
 }
 
 .exam-header,
 .row-flex {
   display: flex;
-  gap: 12px;
+  gap: 16px;
   justify-content: space-between;
   align-items: center;
 }
@@ -314,91 +523,148 @@ textarea {
 }
 
 .autosave-text {
+  color: var(--muted);
   font-size: 0.9rem;
-  color: #64748b;
-  font-weight: 600;
+  font-weight: 800;
 }
 
 .question-progress-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  margin: 20px 0;
+  gap: 9px;
+  margin: 22px 0;
 }
 
 .question-pill {
   width: 42px;
   height: 42px;
-  border-radius: 999px;
   border: 1px solid #cbd5e1;
+  border-radius: 8px;
   background: #ffffff;
-  color: #334155;
-  font-weight: 700;
+  color: #344054;
+  font-weight: 900;
   cursor: pointer;
 }
 
 .question-pill.answered-pill {
-  background: #dbeafe;
-  border-color: #60a5fa;
+  background: #ecfdf3;
+  border-color: #86efac;
+  color: #166534;
 }
 
 .question-pill.active-pill {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #fff;
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #ffffff;
 }
 
 .question-pill:disabled {
-  opacity: 0.4;
+  opacity: 0.38;
   cursor: not-allowed;
 }
 
 .question-card,
 .row-card {
   background: #f8fafc;
-  border: 1px solid #e5e7eb;
-  border-radius: 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--radius);
   padding: 16px;
 }
 
+.question-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 .question-title {
-  margin: 14px 0 8px;
-  color: #111827;
+  margin: 0;
+  color: var(--text);
+  font-size: 1.25rem;
 }
 
 .option-choice {
   display: flex;
-  gap: 10px;
-  align-items: center;
-  margin-top: 12px;
+  gap: 12px;
+  align-items: flex-start;
+  border: 1px solid #e2e8f0;
+  border-radius: 7px;
+  background: #ffffff;
+  padding: 13px 14px;
+  cursor: pointer;
+}
+
+.option-choice:has(input:checked) {
+  border-color: rgba(33, 84, 217, 0.5);
+  background: #eef4ff;
 }
 
 .option-choice input {
   width: auto;
+  margin-top: 4px;
+  accent-color: var(--primary);
 }
 
 .timer-pill {
-  background: #dcfce7;
-  color: #15803d;
-  padding: 12px 20px;
-  border-radius: 999px;
-  font-weight: 800;
+  background: #ecfdf3;
+  color: #166534;
+  padding: 10px 16px;
+  font-weight: 900;
 }
 
 .timer-pill.urgent {
-  background: #fee2e2;
-  color: #b91c1c;
+  background: #fef2f2;
+  color: #b42318;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
+  .login-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .login-hero {
+    min-height: 360px;
+  }
+
+  .metric-grid,
+  .quick-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .login-shell {
+    padding: 18px;
+  }
+
+  .login-hero {
+    display: none;
+  }
+
   .portal-navbar,
-  .nav-links,
   .welcome-banner,
   .exam-header,
   .row-flex,
   .exam-status-block {
+    align-items: stretch;
+  }
+
+  .portal-navbar,
+  .welcome-banner,
+  .exam-header,
+  .row-flex {
     flex-direction: column;
-    align-items: flex-start;
+  }
+
+  .nav-links {
+    display: grid;
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .nav-links button,
+  .logout-btn {
+    width: 100%;
   }
 
   .metric-grid,
@@ -409,7 +675,21 @@ textarea {
     grid-template-columns: 1fr;
   }
 
-  .login-card {
-    padding: 28px;
+  .welcome-banner,
+  .metric-grid,
+  .white-panel,
+  .three-grid,
+  .two-grid,
+  .notice-bar {
+    margin-left: 18px;
+    margin-right: 18px;
+  }
+
+  .metric-card {
+    min-height: 118px;
+  }
+
+  .compact-btn {
+    width: 100%;
   }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -564,7 +564,8 @@ button:focus-visible {
 }
 
 .question-card,
-.row-card {
+.row-card,
+.security-policy-box {
   background: #f8fafc;
   border: 1px solid #e2e8f0;
   border-radius: var(--radius);
@@ -575,6 +576,57 @@ button:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 14px;
+}
+
+.security-policy-box {
+  display: grid;
+  gap: 11px;
+}
+
+.security-policy-box label {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: #344054;
+  font-weight: 700;
+}
+
+.security-policy-box input,
+.security-policy-box input:focus {
+  width: auto;
+  box-shadow: none;
+  accent-color: var(--primary);
+}
+
+.security-policy-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 18px 0 0;
+}
+
+.security-policy-strip span {
+  border: 1px solid #bfd1ff;
+  border-radius: 999px;
+  background: #eef4ff;
+  color: var(--primary-dark);
+  padding: 7px 10px;
+  font-size: 0.84rem;
+  font-weight: 900;
+}
+
+.security-warning {
+  margin-top: 14px;
+  border: 1px solid #fca5a5;
+  border-radius: var(--radius);
+  background: #fef2f2;
+  color: #991b1b;
+  padding: 12px 14px;
+  font-weight: 900;
+}
+
+.wide-panel {
+  grid-column: 1 / -1;
 }
 
 .question-title {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,11 @@ const examBulkTemplate = JSON.stringify(
         title: 'Computer Basics',
         description: 'Introductory MCQ exam',
         duration_minutes: 20,
+        block_clipboard: true,
+        block_context_menu: true,
+        block_inspect_shortcuts: true,
+        enforce_fullscreen: false,
+        track_focus_loss: true,
         questions: [
           {
             question_text: 'CPU stands for?',
@@ -57,6 +62,7 @@ function App({ route = '/login', onNavigate = () => {} }) {
   const [students, setStudents] = useState([])
   const [exams, setExams] = useState([])
   const [assignments, setAssignments] = useState([])
+  const [securityIncidents, setSecurityIncidents] = useState([])
   const [studentForm, setStudentForm] = useState({
     full_name: '',
     username: '',
@@ -69,6 +75,11 @@ function App({ route = '/login', onNavigate = () => {} }) {
     title: '',
     description: '',
     duration_minutes: 30,
+    block_clipboard: true,
+    block_context_menu: true,
+    block_inspect_shortcuts: true,
+    enforce_fullscreen: false,
+    track_focus_loss: true,
     questions: [{ ...defaultQuestion }],
   })
   const [bulkExamsText, setBulkExamsText] = useState(examBulkTemplate)
@@ -83,6 +94,7 @@ function App({ route = '/login', onNavigate = () => {} }) {
   const [isReviewMode, setIsReviewMode] = useState(false)
   const [autosaveState, setAutosaveState] = useState('')
   const [secondsLeft, setSecondsLeft] = useState(0)
+  const [securityWarning, setSecurityWarning] = useState('')
 
   const authHeaders = useMemo(
     () => ({
@@ -141,16 +153,18 @@ function App({ route = '/login', onNavigate = () => {} }) {
   }
 
   const loadAdminData = async () => {
-    const [statsData, studentsData, examsData, assignmentData] = await Promise.all([
+    const [statsData, studentsData, examsData, assignmentData, incidentData] = await Promise.all([
       apiRequest('/api/v1/admin/dashboard'),
       apiRequest('/api/v1/admin/students'),
       apiRequest('/api/v1/admin/exams'),
       apiRequest('/api/v1/admin/assignments'),
+      apiRequest('/api/v1/admin/security-incidents'),
     ])
     setAdminStats(statsData)
     setStudents(studentsData)
     setExams(examsData)
     setAssignments(assignmentData)
+    setSecurityIncidents(incidentData)
   }
 
   const loadStudentData = async () => {
@@ -201,6 +215,86 @@ function App({ route = '/login', onNavigate = () => {} }) {
       submitExam()
     }
   }, [secondsLeft])
+
+  useEffect(() => {
+    if (!liveExam) return
+
+    const logIncident = (incidentType, detail) => {
+      setSecurityWarning(detail)
+      apiRequest(`/api/v1/student/attempts/${liveExam.attempt_id}/security-incidents`, {
+        method: 'POST',
+        body: JSON.stringify({ incident_type: incidentType, detail }),
+      }).catch((error) => setAutosaveState(`Security log failed: ${error.message}`))
+    }
+
+    const blockEvent = (event, incidentType, detail) => {
+      event.preventDefault()
+      logIncident(incidentType, detail)
+    }
+
+    const handleClipboard = (event) => {
+      if (liveExam.block_clipboard) {
+        blockEvent(event, event.type, `${event.type} was blocked during the live exam.`)
+      }
+    }
+
+    const handleContextMenu = (event) => {
+      if (liveExam.block_context_menu) {
+        blockEvent(event, 'context_menu', 'Right-click was blocked during the live exam.')
+      }
+    }
+
+    const handleKeyDown = (event) => {
+      if (!liveExam.block_inspect_shortcuts) return
+      const key = event.key.toLowerCase()
+      const isInspectShortcut =
+        event.key === 'F12' ||
+        (event.ctrlKey && event.shiftKey && ['i', 'j', 'c'].includes(key)) ||
+        (event.metaKey && event.altKey && ['i', 'j', 'c'].includes(key)) ||
+        ((event.ctrlKey || event.metaKey) && key === 'u')
+      if (isInspectShortcut) {
+        blockEvent(event, 'inspect_shortcut', 'Developer-tool shortcut was blocked during the live exam.')
+      }
+    }
+
+    const handleVisibilityChange = () => {
+      if (liveExam.track_focus_loss && document.visibilityState === 'hidden') {
+        logIncident('tab_switch', 'Tab switch or page hide detected during the live exam.')
+      }
+    }
+
+    const handleBlur = () => {
+      if (liveExam.track_focus_loss) {
+        logIncident('window_blur', 'Exam window lost focus during the live exam.')
+      }
+    }
+
+    const handleFullscreenChange = () => {
+      if (liveExam.enforce_fullscreen && !document.fullscreenElement) {
+        logIncident('fullscreen_exit', 'Fullscreen mode was exited during the live exam.')
+      }
+    }
+
+    document.addEventListener('copy', handleClipboard)
+    document.addEventListener('cut', handleClipboard)
+    document.addEventListener('paste', handleClipboard)
+    document.addEventListener('contextmenu', handleContextMenu)
+    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    document.addEventListener('fullscreenchange', handleFullscreenChange)
+    window.addEventListener('blur', handleBlur)
+
+    return () => {
+      document.removeEventListener('copy', handleClipboard)
+      document.removeEventListener('cut', handleClipboard)
+      document.removeEventListener('paste', handleClipboard)
+      document.removeEventListener('contextmenu', handleContextMenu)
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      document.removeEventListener('fullscreenchange', handleFullscreenChange)
+      window.removeEventListener('blur', handleBlur)
+    }
+  }, [liveExam, authHeaders])
 
   const handleLogin = async (event) => {
     event.preventDefault()
@@ -307,6 +401,11 @@ function App({ route = '/login', onNavigate = () => {} }) {
         title: '',
         description: '',
         duration_minutes: 30,
+        block_clipboard: true,
+        block_context_menu: true,
+        block_inspect_shortcuts: true,
+        enforce_fullscreen: false,
+        track_focus_loss: true,
         questions: [{ ...defaultQuestion }],
       })
       setMessage('Exam created successfully')
@@ -354,6 +453,7 @@ function App({ route = '/login', onNavigate = () => {} }) {
         method: 'POST',
       })
       setLiveExam(data)
+      setSecurityWarning('')
       setAnswers(
         Object.fromEntries(
           (data.saved_answers || []).map((answer) => [answer.question_id, answer.selected_option]),
@@ -364,6 +464,11 @@ function App({ route = '/login', onNavigate = () => {} }) {
       setAutosaveState('')
       setSecondsLeft(data.duration_minutes * 60)
       setActiveTab('exam')
+      if (data.enforce_fullscreen && document.documentElement.requestFullscreen) {
+        document.documentElement.requestFullscreen().catch(() => {
+          setSecurityWarning('Fullscreen is required for this exam. Use the browser prompt to enter fullscreen.')
+        })
+      }
     } catch (error) {
       setMessage(error.message)
     }
@@ -406,6 +511,7 @@ function App({ route = '/login', onNavigate = () => {} }) {
       setMessage(`Exam submitted. Score ${result.score}/${result.total_marks} (${result.percentage}%)`)
       setLiveExam(null)
       setAnswers({})
+      setSecurityWarning('')
       setCurrentQuestionIndex(0)
       setIsReviewMode(false)
       setAutosaveState('')
@@ -713,6 +819,62 @@ function App({ route = '/login', onNavigate = () => {} }) {
                     setExamForm((current) => ({ ...current, description: event.target.value }))
                   }
                 />
+                <div className="security-policy-box">
+                  <strong>Security Policies</strong>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={examForm.block_clipboard}
+                      onChange={(event) =>
+                        setExamForm((current) => ({ ...current, block_clipboard: event.target.checked }))
+                      }
+                    />
+                    Block copy, paste, and cut
+                  </label>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={examForm.block_context_menu}
+                      onChange={(event) =>
+                        setExamForm((current) => ({ ...current, block_context_menu: event.target.checked }))
+                      }
+                    />
+                    Block right-click menu
+                  </label>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={examForm.block_inspect_shortcuts}
+                      onChange={(event) =>
+                        setExamForm((current) => ({
+                          ...current,
+                          block_inspect_shortcuts: event.target.checked,
+                        }))
+                      }
+                    />
+                    Block inspect/developer shortcuts
+                  </label>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={examForm.track_focus_loss}
+                      onChange={(event) =>
+                        setExamForm((current) => ({ ...current, track_focus_loss: event.target.checked }))
+                      }
+                    />
+                    Log tab switches and window focus loss
+                  </label>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={examForm.enforce_fullscreen}
+                      onChange={(event) =>
+                        setExamForm((current) => ({ ...current, enforce_fullscreen: event.target.checked }))
+                      }
+                    />
+                    Require fullscreen during exam
+                  </label>
+                </div>
                 {examForm.questions.map((question, index) => (
                   <div className="question-card" key={`q-${index + 1}`}>
                     <input
@@ -849,6 +1011,25 @@ function App({ route = '/login', onNavigate = () => {} }) {
                 ))}
               </div>
             </article>
+            <article className="white-panel wide-panel">
+              <h2>Security Incident Report</h2>
+              <div className="list-stack">
+                {securityIncidents.length ? (
+                  securityIncidents.map((incident) => (
+                    <div className="row-card" key={incident.id}>
+                      <strong>{incident.incident_type.replaceAll('_', ' ')}</strong>
+                      <p>
+                        {incident.student_name || 'Student'} | {incident.exam_title || 'Exam'} |{' '}
+                        {new Date(incident.occurred_at).toLocaleString()}
+                      </p>
+                      <p>{incident.detail}</p>
+                    </div>
+                  ))
+                ) : (
+                  <p className="helper-text">No security incidents logged yet.</p>
+                )}
+              </div>
+            </article>
           </section>
         )}
       </main>
@@ -914,6 +1095,13 @@ function App({ route = '/login', onNavigate = () => {} }) {
                   <span className="autosave-text">{autosaveState || 'Autosave ready'}</span>
                 </div>
               </div>
+              <div className="security-policy-strip">
+                <span>{liveExam.block_clipboard ? 'Clipboard blocked' : 'Clipboard allowed'}</span>
+                <span>{liveExam.block_context_menu ? 'Right-click blocked' : 'Right-click allowed'}</span>
+                <span>{liveExam.track_focus_loss ? 'Focus monitored' : 'Focus not monitored'}</span>
+                <span>{liveExam.enforce_fullscreen ? 'Fullscreen required' : 'Fullscreen optional'}</span>
+              </div>
+              {securityWarning ? <div className="security-warning">{securityWarning}</div> : null}
               <div className="question-progress-row">
                 {liveExam.questions.map((question, index) => (
                   <button

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -439,8 +439,23 @@ function App({ route = '/login', onNavigate = () => {} }) {
   if (!session) {
     return (
       <main className="login-shell">
+        <aside className="login-hero" aria-hidden="true">
+          <div className="hero-kicker">Trusted assessment workspace</div>
+          <h1>Secure exams, calmer operations.</h1>
+          <p>
+            Run assignments, monitor completion, and give students a focused testing experience.
+          </p>
+          <div className="hero-stats">
+            <span>Live autosave</span>
+            <span>Role dashboards</span>
+            <span>Bulk setup</span>
+          </div>
+        </aside>
         <section className="login-card">
-          <div className="brand-mark">🎓 Secure Exam Portal</div>
+          <div className="brand-mark">
+            <span className="brand-icon">S</span>
+            <span>Secure Exam Portal</span>
+          </div>
           <div className="auth-tab-row">
             <button
               type="button"
@@ -578,16 +593,16 @@ function App({ route = '/login', onNavigate = () => {} }) {
           <h2>Quick Actions</h2>
           <div className="quick-grid">
             <button className="action-btn blue" onClick={() => setActiveTab('exams')} type="button">
-              + Create New Exam
+              Create New Exam
             </button>
             <button className="action-btn green" onClick={() => setActiveTab('users')} type="button">
-              👤 Manage Users
+              Manage Users
             </button>
             <button className="action-btn cyan" onClick={() => setActiveTab('reports')} type="button">
-              📈 View Reports
+              View Reports
             </button>
             <button className="action-btn yellow" onClick={() => setActiveTab('exams')} type="button">
-              ☰ Manage Exams
+              Manage Exams
             </button>
           </div>
         </section>
@@ -1050,7 +1065,10 @@ function App({ route = '/login', onNavigate = () => {} }) {
   function renderTopbar(tabs) {
     return (
       <header className="portal-navbar">
-        <div className="brand-area">🎓 Secure Exam Portal</div>
+        <div className="brand-area">
+          <span className="brand-icon">S</span>
+          <span>Secure Exam Portal</span>
+        </div>
         <nav className="nav-links">
           {tabs.map((tab) => (
             <button


### PR DESCRIPTION
Closes #30

## Summary
- Add configurable per-exam security policies for clipboard, context menu, inspect shortcuts, fullscreen, and focus tracking.
- Log student security incidents from live exam sessions and expose the latest incidents in the admin reports view.
- Add startup compatibility for existing exam tables that need the new policy columns.

## Verification
- npm run lint
- npm run build
- DATABASE_URL=sqlite:////private/tmp/secure_exam_portal_check.db python3 -c "from app.extensions.db import init_db; init_db(); print('init ok')"
- python3 -m compileall app