### PR TITLE
Add Docker image publishing workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,118 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_OWNER: ${{ github.repository_owner }}
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.service }} image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: backend
+            image: secure-exam-backend
+            context: ./backend
+            file: ./backend/docker/Dockerfile
+          - service: frontend
+            image: secure-exam-frontend
+            context: ./frontend
+            file: ./frontend/Dockerfile
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=${{ matrix.image }}
+            org.opencontainers.image.description=Secure Exam Portal ${{ matrix.service }} image
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+      - name: Write image summary
+        run: |
+          {
+            echo "### ${{ matrix.service }} image"
+            echo ""
+            echo "Published tags:"
+            echo '${{ steps.meta.outputs.tags }}' | sed 's/^/- /'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create release notes
+        run: |
+          cat > release-notes.md <<'NOTES'
+          ## Docker Images
+
+          Published GitHub Packages:
+
+          - `ghcr.io/${{ github.repository_owner }}/secure-exam-backend:${{ github.ref_name }}`
+          - `ghcr.io/${{ github.repository_owner }}/secure-exam-frontend:${{ github.ref_name }}`
+
+          The `latest` tag is also updated for builds from `main`.
+          NOTES
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-notes.md

--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ docker push sameeralam3127/secure-exam-backend:latest
 docker push sameeralam3127/secure-exam-frontend:latest
 ```
 
+## GitHub Packages and Releases
+
+Docker images are published to GitHub Container Registry by the `Build and Publish Docker Images`
+workflow.
+
+Published package names:
+
+```text
+ghcr.io/sameeralam3127/secure-exam-backend
+ghcr.io/sameeralam3127/secure-exam-frontend
+```
+
+Publishing rules:
+
+- Push to `main` publishes `latest`, `main`, and `sha-*` image tags.
+- Push a version tag like `v1.0.0` to publish versioned images and create a GitHub Release.
+- Publishing a GitHub Release also runs the Docker image workflow.
+
+Create a release build:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
 ## API Surface
 
 Main versioned endpoints:


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build backend and frontend Docker images.
- Publish images to GitHub Container Registry under GitHub Packages.
- Create GitHub Releases automatically for pushed v* tags with image references.
- Document package names and release trigger steps in README.

## Verification
- Parsed workflow YAML locally with Ruby YAML parser.