### PR TITLE
Publish frontend and backend as a single Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,20 +21,8 @@ env:
 
 jobs:
   publish:
-    name: Publish ${{ matrix.service }} image
+    name: Publish single application image
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - service: backend
-            image: secure-exam-backend
-            context: ./backend
-            file: ./backend/docker/Dockerfile
-          - service: frontend
-            image: secure-exam-frontend
-            context: ./frontend
-            file: ./frontend/Dockerfile
 
     steps:
       - name: Checkout repository
@@ -54,7 +42,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/secure-exam-portal
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
@@ -64,24 +52,24 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-
           labels: |
-            org.opencontainers.image.title=${{ matrix.image }}
-            org.opencontainers.image.description=Secure Exam Portal ${{ matrix.service }} image
+            org.opencontainers.image.title=secure-exam-portal
+            org.opencontainers.image.description=Secure Exam Portal combined frontend and backend image
 
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
+          context: .
+          file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.service }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+          cache-from: type=gha,scope=secure-exam-portal
+          cache-to: type=gha,mode=max,scope=secure-exam-portal
 
       - name: Write image summary
         run: |
           {
-            echo "### ${{ matrix.service }} image"
+            echo "### Secure Exam Portal image"
             echo ""
             echo "Published tags:"
             echo '${{ steps.meta.outputs.tags }}' | sed 's/^/- /'
@@ -106,8 +94,7 @@ jobs:
 
           Published GitHub Packages:
 
-          - `ghcr.io/${{ github.repository_owner }}/secure-exam-backend:${{ github.ref_name }}`
-          - `ghcr.io/${{ github.repository_owner }}/secure-exam-frontend:${{ github.ref_name }}`
+          - `ghcr.io/${{ github.repository_owner }}/secure-exam-portal:${{ github.ref_name }}`
 
           The `latest` tag is also updated for builds from `main`.
           NOTES

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM node:20-alpine AS frontend-build
+
+WORKDIR /frontend
+
+COPY frontend/package*.json ./
+RUN npm ci
+
+COPY frontend/ ./
+ARG VITE_API_BASE_URL=/api
+ARG VITE_GOOGLE_CLIENT_ID=
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID
+RUN npm run build
+
+
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV ENVIRONMENT=production
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nginx \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /etc/nginx/sites-enabled/default
+
+COPY backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ ./
+COPY --from=frontend-build /frontend/dist /usr/share/nginx/html
+COPY docker/single-image-nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker/start-single-image.sh /usr/local/bin/start-single-image.sh
+
+RUN chmod +x /usr/local/bin/start-single-image.sh
+
+EXPOSE 80
+
+CMD ["/usr/local/bin/start-single-image.sh"]

--- a/README.md
+++ b/README.md
@@ -70,14 +70,13 @@ Production-style stack built from this repository:
 docker compose up --build
 ```
 
-Production stack using the published Docker Hub images:
+Production stack using the published GitHub Packages image:
 
 ```bash
-docker pull sameeralam3127/secure-exam-backend:latest
-docker pull sameeralam3127/secure-exam-frontend:latest
+docker pull ghcr.io/sameeralam3127/secure-exam-portal:latest
 ```
 
-Create `.env` from `.env.example`, set the required production values, then use the published images in your deployment:
+Create `.env` from `.env.example`, set the required production values, then use the published image in your deployment:
 
 ```yaml
 services:
@@ -90,8 +89,10 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
-  backend:
-    image: sameeralam3127/secure-exam-backend:latest
+  app:
+    image: ghcr.io/sameeralam3127/secure-exam-portal:latest
+    ports:
+      - "80:80"
     environment:
       ENVIRONMENT: production
       AUTH_SECRET_KEY: ${AUTH_SECRET_KEY}
@@ -112,13 +113,6 @@ services:
     depends_on:
       - db
 
-  frontend:
-    image: sameeralam3127/secure-exam-frontend:latest
-    ports:
-      - "80:80"
-    depends_on:
-      - backend
-
 volumes:
   postgres_data:
 ```
@@ -135,27 +129,24 @@ Local development URLs:
 - Backend API: `http://localhost:8001`
 - API docs: `http://localhost:8001/docs`
 
-## Docker Hub Images
+## Docker Image
 
-Published images:
+Published image:
 
 ```text
-sameeralam3127/secure-exam-backend:latest
-sameeralam3127/secure-exam-frontend:latest
+ghcr.io/sameeralam3127/secure-exam-portal:latest
 ```
 
-Build images locally:
+Build the image locally:
 
 ```bash
-docker build -t sameeralam3127/secure-exam-backend:latest -f backend/docker/Dockerfile backend
-docker build -t sameeralam3127/secure-exam-frontend:latest frontend
+docker build -t secure-exam-portal:local .
 ```
 
-Push images:
+Run the local image:
 
 ```bash
-docker push sameeralam3127/secure-exam-backend:latest
-docker push sameeralam3127/secure-exam-frontend:latest
+docker run --env-file .env -p 80:80 secure-exam-portal:local
 ```
 
 ## GitHub Packages and Releases
@@ -163,11 +154,10 @@ docker push sameeralam3127/secure-exam-frontend:latest
 Docker images are published to GitHub Container Registry by the `Build and Publish Docker Images`
 workflow.
 
-Published package names:
+Published package name:
 
 ```text
-ghcr.io/sameeralam3127/secure-exam-backend
-ghcr.io/sameeralam3127/secure-exam-frontend
+ghcr.io/sameeralam3127/secure-exam-portal
 ```
 
 Publishing rules:

--- a/docker/single-image-nginx.conf
+++ b/docker/single-image-nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker/start-single-image.sh
+++ b/docker/start-single-image.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+gunicorn app.main:app \
+  -k uvicorn.workers.UvicornWorker \
+  --bind 127.0.0.1:8000 \
+  --workers "${WEB_CONCURRENCY:-3}" &
+
+backend_pid="$!"
+
+term_handler() {
+  kill "$backend_pid" 2>/dev/null || true
+  nginx -s quit 2>/dev/null || true
+  wait "$backend_pid" 2>/dev/null || true
+}
+
+trap term_handler INT TERM
+
+nginx -g "daemon off;" &
+nginx_pid="$!"
+
+wait "$nginx_pid"


### PR DESCRIPTION
## Summary
- Add a root Dockerfile that builds the React frontend and FastAPI backend into one production image.
- Run Nginx and Gunicorn in the same container, with Nginx serving the frontend and proxying /api to the backend.
- Update the Docker publishing workflow to publish one GHCR package: ghcr.io/sameeralam3127/secure-exam-portal.
- Update README deployment and release documentation for the single image.

## Verification
- docker build -t secure-exam-portal:single-test .
- Ruby YAML parse for .github/workflows/docker-publish.yml