### PR TITLE
[codex] Harden Docker pip installs against network timeouts

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -3,11 +3,14 @@ FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV ENVIRONMENT=production
+ENV PIP_DEFAULT_TIMEOUT=120
+ENV PIP_RETRIES=10
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --retries 10 --timeout 120 -r requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- Added pip timeout and retry defaults to the backend Docker image build.
- Passed explicit --retries and --timeout flags to the requirements install step.
- Suppressed pip version-check noise during image builds.

## Why
The development Compose build failed while installing backend dependencies because pip timed out during a wheel download. The app code was not failing; the Docker build needed more tolerant package-download settings.

## Validation
- docker build -f backend/docker/Dockerfile backend
- docker compose -f docker-compose.dev.yml build backend worker
- git diff --check