### PR TITLE
Redesign admin dashboard into a pro sidebar layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1154,3 +1154,401 @@ button:focus-visible {
   opacity: 0.45;
   cursor: not-allowed;
 }
+
+/* ============================================================
+   Pro admin dashboard: dark sidebar + light content shell.
+   All content overrides are scoped under .admin-shell so the
+   student portal styling is untouched.
+   ============================================================ */
+.admin-shell {
+  --sidebar-w: 250px;
+  --sidebar-collapsed: 78px;
+  --acc: #4f46e5;
+  --acc-soft: rgba(99, 102, 241, 0.16);
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: var(--sidebar-w) minmax(0, 1fr);
+  background: #f5f7fb;
+}
+.admin-shell.is-collapsed {
+  grid-template-columns: var(--sidebar-collapsed) minmax(0, 1fr);
+}
+
+/* ---- Sidebar ---- */
+.admin-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 18px 14px;
+  background: linear-gradient(185deg, #131a2e 0%, #0d1322 100%);
+  border-right: 1px solid rgba(148, 163, 184, 0.12);
+  overflow-y: auto;
+}
+.admin-brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 6px 8px 16px;
+  color: #f8fafc;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+}
+.admin-brand-icon {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  background: linear-gradient(135deg, #6366f1, #4338ca);
+  box-shadow: 0 6px 16px rgba(67, 56, 202, 0.45);
+}
+.admin-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+.admin-nav-item,
+.admin-logout {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: #94a3b8;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.admin-nav-item:hover {
+  background: rgba(148, 163, 184, 0.1);
+  color: #e2e8f0;
+}
+.admin-nav-item.active {
+  position: relative;
+  background: var(--acc-soft);
+  color: #fff;
+}
+.admin-nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: -14px;
+  top: 8px;
+  bottom: 8px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: #818cf8;
+}
+.admin-nav-item svg,
+.admin-logout svg {
+  flex: none;
+}
+.admin-sidebar-footer {
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.admin-user {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 6px 8px;
+}
+.admin-avatar {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: 0.85rem;
+  color: #fff;
+  background: linear-gradient(135deg, #334155, #1e293b);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+.admin-user-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.admin-user-meta strong {
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.admin-user-meta span {
+  color: #64748b;
+  font-size: 0.8rem;
+}
+.admin-logout:hover {
+  background: rgba(239, 68, 68, 0.14);
+  color: #fca5a5;
+}
+
+/* ---- Main column ---- */
+.admin-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.admin-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 15;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 15px 28px;
+  background: rgba(245, 247, 251, 0.82);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid #e6ebf2;
+}
+.admin-topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.admin-page-heading h1 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.01em;
+}
+.admin-page-heading p {
+  margin: 2px 0 0;
+  color: #64748b;
+  font-size: 0.86rem;
+}
+.admin-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.admin-icon-btn {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #fff;
+  color: #475569;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.admin-icon-btn:hover {
+  background: #eef2ff;
+  color: var(--acc);
+  border-color: #c7d2fe;
+}
+.admin-role-pill {
+  padding: 7px 14px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #4338ca;
+  font-weight: 800;
+  font-size: 0.8rem;
+}
+.admin-menu-btn { display: none; }
+.admin-scrim { display: none; }
+
+.admin-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px 28px 48px;
+  width: 100%;
+  max-width: 1440px;
+}
+
+/* Reset the student-portal 5vw side margins inside the shell. */
+.admin-shell .welcome-banner,
+.admin-shell .metric-grid,
+.admin-shell .white-panel,
+.admin-shell .two-grid,
+.admin-shell .three-grid,
+.admin-shell .dashboard-grid,
+.admin-shell .admin-stack,
+.admin-shell .notice-bar {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+/* ---- Stat tiles ---- */
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+.stat-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 18px;
+  background: #fff;
+  border: 1px solid #e6ebf2;
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
+  transition: box-shadow 0.18s, transform 0.18s;
+}
+.stat-tile:hover {
+  box-shadow: 0 10px 26px rgba(16, 24, 40, 0.08);
+  transform: translateY(-2px);
+}
+.stat-tile-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.stat-chip {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+}
+.stat-value {
+  font-size: 1.95rem;
+  font-weight: 800;
+  line-height: 1;
+  color: #0f172a;
+}
+.stat-label {
+  color: #64748b;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+.stat-helper {
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 0.78rem;
+}
+.stat-tile.tone-blue .stat-chip { background: #eaf1ff; color: #2563eb; }
+.stat-tile.tone-violet .stat-chip { background: #f1ecff; color: #7c3aed; }
+.stat-tile.tone-teal .stat-chip { background: #e3f7f2; color: #0d9488; }
+.stat-tile.tone-amber .stat-chip { background: #fff2e0; color: #d97706; }
+.stat-tile.tone-rose .stat-chip { background: #fdebef; color: #e11d48; }
+
+/* ---- Panels / tables / forms scoped to the shell ---- */
+.admin-shell .white-panel {
+  padding: 20px 22px;
+  background: #fff;
+  border: 1px solid #e6ebf2;
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
+}
+.admin-shell .white-panel h2 {
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+.admin-shell .dashboard-grid { gap: 16px; }
+.admin-shell .table-row {
+  border-bottom: 1px solid #eef2f7;
+}
+.admin-shell .table-head {
+  color: #94a3b8;
+  letter-spacing: 0.05em;
+}
+.admin-shell .table-row:not(.table-head):hover {
+  background: #f8fafc;
+}
+.admin-shell input:not([type="checkbox"]):not([type="radio"]),
+.admin-shell textarea,
+.admin-shell select {
+  border: 1px solid #dbe2ec;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: #fff;
+  font-family: inherit;
+  font-size: 0.92rem;
+  color: #0f172a;
+}
+.admin-shell input:focus-visible,
+.admin-shell textarea:focus-visible,
+.admin-shell select:focus-visible {
+  outline: 2px solid #818cf8;
+  outline-offset: 1px;
+  border-color: #818cf8;
+}
+.admin-shell .action-btn {
+  border-radius: 10px;
+}
+.admin-shell .action-btn.blue { background: var(--acc); }
+.admin-shell .action-btn.blue:hover { background: #4338ca; }
+
+/* ---- Collapsed (desktop) ---- */
+.admin-shell.is-collapsed .admin-brand-text,
+.admin-shell.is-collapsed .admin-nav-label,
+.admin-shell.is-collapsed .admin-user-meta {
+  display: none;
+}
+.admin-shell.is-collapsed .admin-nav-item,
+.admin-shell.is-collapsed .admin-logout,
+.admin-shell.is-collapsed .admin-user,
+.admin-shell.is-collapsed .admin-brand {
+  justify-content: center;
+}
+.admin-shell.is-collapsed .admin-nav-item.active::before { left: -14px; }
+
+/* ---- Responsive: off-canvas sidebar ---- */
+@media (max-width: 1024px) {
+  .admin-shell,
+  .admin-shell.is-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .admin-sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 264px;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    z-index: 60;
+  }
+  .admin-shell.is-open .admin-sidebar { transform: none; }
+  .admin-shell.is-collapsed .admin-brand-text,
+  .admin-shell.is-collapsed .admin-nav-label,
+  .admin-shell.is-collapsed .admin-user-meta { display: block; }
+  .admin-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: 0;
+    background: rgba(2, 6, 23, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    z-index: 50;
+  }
+  .admin-shell.is-open .admin-scrim { opacity: 1; pointer-events: auto; }
+  .admin-menu-btn { display: grid; }
+  .admin-collapse-btn { display: none; }
+  .admin-content { padding: 20px 18px 40px; }
+  .admin-topbar { padding: 14px 18px; }
+  .stat-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 560px) {
+  .stat-row { grid-template-columns: minmax(0, 1fr); }
+  .admin-page-heading p { display: none; }
+}

--- a/frontend/src/components/admin/AdminAnalytics.jsx
+++ b/frontend/src/components/admin/AdminAnalytics.jsx
@@ -1,4 +1,4 @@
-import { MetricCard, PanelHeader, ProgressBar } from '../ui.jsx'
+import { PanelHeader, ProgressBar, StatTile } from '../ui.jsx'
 
 function formatAction(action) {
   return action.replaceAll('.', ' · ').replaceAll('_', ' ')
@@ -18,11 +18,11 @@ export default function AdminAnalytics({ analytics, auditEvents }) {
 
   return (
     <section className="admin-stack">
-      <section className="metric-grid">
-        <MetricCard color="blue" count={analytics.total_exams} label="Exams" icon="EX" helper={`${analytics.active_exams} active`} />
-        <MetricCard color="green" count={assignments.total} label="Assignments" icon="AS" helper={`${assignments.submitted} submitted`} />
-        <MetricCard color="cyan" count={`${results.average_score}%`} label="Average Score" icon="AV" helper={`${results.submitted_attempts} attempts`} />
-        <MetricCard color="orange" count={incidents.total} label="Security Incidents" icon="SI" helper={`${incidentTypes.length} types`} />
+      <section className="stat-row">
+        <StatTile tone="violet" icon="exams" value={analytics.total_exams} label="Exams" helper={`${analytics.active_exams} active`} />
+        <StatTile tone="blue" icon="assignments" value={assignments.total} label="Assignments" helper={`${assignments.submitted} submitted`} />
+        <StatTile tone="teal" icon="analytics" value={`${results.average_score}%`} label="Average Score" helper={`${results.submitted_attempts} attempts`} />
+        <StatTile tone="rose" icon="shield" value={incidents.total} label="Security Incidents" helper={`${incidentTypes.length} types`} />
       </section>
 
       <section className="two-grid">

--- a/frontend/src/components/admin/AdminDashboard.jsx
+++ b/frontend/src/components/admin/AdminDashboard.jsx
@@ -2,80 +2,91 @@ import { useState } from 'react'
 
 import { getAdminDashboardModel } from '../../dashboardModel.js'
 import { useAdminPortal } from '../../hooks/useAdminPortal.js'
-import Topbar from '../Topbar.jsx'
-import { MetricCard, Notice } from '../ui.jsx'
+import { Notice, StatTile } from '../ui.jsx'
 import AdminAnalytics from './AdminAnalytics.jsx'
 import AdminOverview from './AdminOverview.jsx'
 import AdminReports from './AdminReports.jsx'
+import AdminShell from './AdminShell.jsx'
 import AssignExam from './AssignExam.jsx'
 import ExamBuilder from './ExamBuilder.jsx'
 import ManageUsers from './ManageUsers.jsx'
 
-const TABS = [
-  { key: 'dashboard', label: 'Dashboard' },
-  { key: 'exams', label: 'Exams' },
-  { key: 'assignments', label: 'Assignments' },
-  { key: 'users', label: 'Users' },
-  { key: 'analytics', label: 'Analytics' },
-  { key: 'reports', label: 'Reports' },
+const NAV_ITEMS = [
+  { key: 'dashboard', label: 'Overview', icon: 'dashboard' },
+  { key: 'exams', label: 'Exams', icon: 'exams' },
+  { key: 'assignments', label: 'Assignments', icon: 'assignments' },
+  { key: 'users', label: 'Users', icon: 'users' },
+  { key: 'analytics', label: 'Analytics', icon: 'analytics' },
+  { key: 'reports', label: 'Reports', icon: 'reports' },
 ]
 
-export default function AdminDashboard({ api, message, setMessage, onLogout }) {
+const PAGE_META = {
+  dashboard: { title: 'Overview', subtitle: 'Monitor exams, assignments, and security at a glance.' },
+  exams: { title: 'Exams', subtitle: 'Author exams and manage the question bank.' },
+  assignments: { title: 'Assignments', subtitle: 'Assign exams to students and track delivery.' },
+  users: { title: 'Users', subtitle: 'Create, search, and manage student accounts.' },
+  analytics: { title: 'Analytics', subtitle: 'Results, completion, and operational metrics.' },
+  reports: { title: 'Reports', subtitle: 'Score reports and the security incident log.' },
+}
+
+export default function AdminDashboard({ api, user, message, setMessage, onLogout }) {
   const [activeTab, setActiveTab] = useState('dashboard')
   const admin = useAdminPortal(api, setMessage)
 
   const model = getAdminDashboardModel(admin.adminStats, admin.assignments, admin.securityIncidents)
+  const meta = PAGE_META[activeTab] || PAGE_META.dashboard
 
   return (
-    <main className="portal-page">
-      <Topbar tabs={TABS} activeTab={activeTab} onSelect={setActiveTab} onLogout={onLogout} />
-
-      <section className="welcome-banner">
-        <div>
-          <h1>Admin Dashboard</h1>
-          <p>Monitor exams, assignments, student activity, and security events.</p>
-        </div>
-        <div className="banner-actions">
-          <span className="role-chip">Admin Console</span>
-          <button className="ghost-btn" type="button" onClick={admin.loadAdminData}>
-            Refresh
-          </button>
-        </div>
-      </section>
-
-      <section className="metric-grid">
-        <MetricCard color="blue" count={admin.adminStats?.total_students || 0} label="Students" icon="ST" helper="Active learner records" />
-        <MetricCard color="green" count={admin.adminStats?.total_exams || 0} label="Exams" icon="EX" helper={`${admin.adminStats?.total_assignments || 0} assignments`} />
-        <MetricCard color="cyan" count={`${model.completionRate}%`} label="Completion Rate" icon="CR" helper={`${model.pendingAssignments.length} pending`} />
-        <MetricCard color="orange" count={admin.adminStats?.completed_attempts || 0} label="Submitted Attempts" icon="SA" helper={`${model.averageScore}% average`} />
-      </section>
-
+    <AdminShell
+      navItems={NAV_ITEMS}
+      activeTab={activeTab}
+      onSelect={setActiveTab}
+      title={meta.title}
+      subtitle={meta.subtitle}
+      user={user}
+      onRefresh={admin.loadAdminData}
+      onLogout={onLogout}
+    >
       <Notice message={message} />
 
-      <section className="white-panel">
-        <h2>Quick Actions</h2>
-        <div className="quick-grid">
-          <button className="action-btn blue" onClick={() => setActiveTab('exams')} type="button">
-            Create New Exam
-          </button>
-          <button className="action-btn green" onClick={() => setActiveTab('users')} type="button">
-            Manage Users
-          </button>
-          <button className="action-btn cyan" onClick={() => setActiveTab('reports')} type="button">
-            View Reports
-          </button>
-          <button className="action-btn yellow" onClick={() => setActiveTab('assignments')} type="button">
-            Assign Exam
-          </button>
-        </div>
-      </section>
-
       {activeTab === 'dashboard' && (
-        <AdminOverview
-          model={model}
-          assignments={admin.assignments}
-          securityIncidents={admin.securityIncidents}
-        />
+        <>
+          <section className="stat-row">
+            <StatTile
+              tone="blue"
+              icon="users"
+              value={admin.adminStats?.total_students || 0}
+              label="Students"
+              helper="Active records"
+            />
+            <StatTile
+              tone="violet"
+              icon="exams"
+              value={admin.adminStats?.total_exams || 0}
+              label="Exams"
+              helper={`${admin.adminStats?.total_assignments || 0} assignments`}
+            />
+            <StatTile
+              tone="teal"
+              icon="analytics"
+              value={`${model.completionRate}%`}
+              label="Completion"
+              helper={`${model.pendingAssignments.length} pending`}
+            />
+            <StatTile
+              tone="amber"
+              icon="reports"
+              value={admin.adminStats?.completed_attempts || 0}
+              label="Submitted"
+              helper={`${model.averageScore}% avg score`}
+            />
+          </section>
+          <AdminOverview
+            model={model}
+            assignments={admin.assignments}
+            securityIncidents={admin.securityIncidents}
+          />
+        </>
       )}
 
       {activeTab === 'users' && (
@@ -124,11 +135,8 @@ export default function AdminDashboard({ api, message, setMessage, onLogout }) {
       )}
 
       {activeTab === 'reports' && (
-        <AdminReports
-          assignments={admin.assignments}
-          securityIncidents={admin.securityIncidents}
-        />
+        <AdminReports assignments={admin.assignments} securityIncidents={admin.securityIncidents} />
       )}
-    </main>
+    </AdminShell>
   )
 }

--- a/frontend/src/components/admin/AdminShell.jsx
+++ b/frontend/src/components/admin/AdminShell.jsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+
+import Icon from '../icons.jsx'
+
+/**
+ * Professional admin layout: a dark, collapsible sidebar for navigation and a
+ * light content area with a sticky topbar. Purely presentational — nav state
+ * and page content come from props.
+ */
+export default function AdminShell({
+  navItems,
+  activeTab,
+  onSelect,
+  title,
+  subtitle,
+  user,
+  onRefresh,
+  onLogout,
+  children,
+}) {
+  const [collapsed, setCollapsed] = useState(false)
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  const initials = (user?.full_name || 'A')
+    .split(' ')
+    .map((part) => part[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+
+  return (
+    <div className={`admin-shell ${collapsed ? 'is-collapsed' : ''} ${mobileOpen ? 'is-open' : ''}`}>
+      <aside className="admin-sidebar">
+        <div className="admin-brand">
+          <span className="admin-brand-icon">
+            <Icon name="shield" size={20} />
+          </span>
+          <span className="admin-brand-text">Secure Exam</span>
+        </div>
+
+        <nav className="admin-nav" aria-label="Admin sections">
+          {navItems.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              className={activeTab === item.key ? 'admin-nav-item active' : 'admin-nav-item'}
+              aria-current={activeTab === item.key ? 'page' : undefined}
+              onClick={() => {
+                onSelect(item.key)
+                setMobileOpen(false)
+              }}
+            >
+              <Icon name={item.icon} size={19} />
+              <span className="admin-nav-label">{item.label}</span>
+            </button>
+          ))}
+        </nav>
+
+        <div className="admin-sidebar-footer">
+          <div className="admin-user">
+            <span className="admin-avatar">{initials}</span>
+            <div className="admin-user-meta">
+              <strong>{user?.full_name || 'Administrator'}</strong>
+              <span>@{user?.username || 'admin'}</span>
+            </div>
+          </div>
+          <button type="button" className="admin-logout" onClick={onLogout}>
+            <Icon name="logout" size={18} />
+            <span className="admin-nav-label">Sign out</span>
+          </button>
+        </div>
+      </aside>
+
+      <button
+        type="button"
+        className="admin-scrim"
+        aria-label="Close menu"
+        onClick={() => setMobileOpen(false)}
+      />
+
+      <div className="admin-main">
+        <header className="admin-topbar">
+          <div className="admin-topbar-left">
+            <button
+              type="button"
+              className="admin-icon-btn admin-menu-btn"
+              aria-label="Toggle menu"
+              onClick={() => setMobileOpen((open) => !open)}
+            >
+              <Icon name="menu" size={20} />
+            </button>
+            <button
+              type="button"
+              className="admin-icon-btn admin-collapse-btn"
+              aria-label="Collapse sidebar"
+              onClick={() => setCollapsed((value) => !value)}
+            >
+              <Icon name="menu" size={20} />
+            </button>
+            <div className="admin-page-heading">
+              <h1>{title}</h1>
+              {subtitle ? <p>{subtitle}</p> : null}
+            </div>
+          </div>
+          <div className="admin-topbar-actions">
+            <button type="button" className="admin-icon-btn" aria-label="Refresh data" onClick={onRefresh}>
+              <Icon name="refresh" size={18} />
+            </button>
+            <span className="admin-role-pill">Admin</span>
+          </div>
+        </header>
+
+        <div className="admin-content">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/icons.jsx
+++ b/frontend/src/components/icons.jsx
@@ -1,0 +1,94 @@
+// Lightweight inline stroke icons (currentColor, 20x20) — no external deps.
+const PATHS = {
+  dashboard: (
+    <>
+      <rect x="3" y="3" width="7" height="7" rx="1.5" />
+      <rect x="14" y="3" width="7" height="7" rx="1.5" />
+      <rect x="14" y="14" width="7" height="7" rx="1.5" />
+      <rect x="3" y="14" width="7" height="7" rx="1.5" />
+    </>
+  ),
+  exams: (
+    <>
+      <path d="M6 2h9l4 4v16H6z" />
+      <path d="M14 2v5h5" />
+      <path d="M9 12h7M9 16h7" />
+    </>
+  ),
+  assignments: (
+    <>
+      <rect x="5" y="4" width="14" height="17" rx="2" />
+      <path d="M9 4V3h6v1" />
+      <path d="M9 11l2 2 4-4" />
+    </>
+  ),
+  users: (
+    <>
+      <circle cx="9" cy="8" r="3.2" />
+      <path d="M3.5 20a5.5 5.5 0 0 1 11 0" />
+      <path d="M16 4.5a3 3 0 0 1 0 6M21 20a5 5 0 0 0-4-4.9" />
+    </>
+  ),
+  analytics: (
+    <>
+      <path d="M4 20V10M10 20V4M16 20v-7M22 20H2" />
+    </>
+  ),
+  reports: (
+    <>
+      <path d="M6 2h12v20l-6-3-6 3z" />
+      <path d="M9 8h6M9 12h6" />
+    </>
+  ),
+  refresh: (
+    <>
+      <path d="M20 11a8 8 0 1 0-1.5 5" />
+      <path d="M20 4v6h-6" />
+    </>
+  ),
+  logout: (
+    <>
+      <path d="M15 4h3a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-3" />
+      <path d="M10 17l-5-5 5-5" />
+      <path d="M5 12h12" />
+    </>
+  ),
+  shield: (
+    <>
+      <path d="M12 2l8 3v6c0 5-3.4 8.5-8 11-4.6-2.5-8-6-8-11V5z" />
+      <path d="M9 12l2 2 4-4" />
+    </>
+  ),
+  search: (
+    <>
+      <circle cx="11" cy="11" r="7" />
+      <path d="M21 21l-4-4" />
+    </>
+  ),
+  menu: (
+    <>
+      <path d="M3 6h18M3 12h18M3 18h18" />
+    </>
+  ),
+}
+
+export default function Icon({ name, size = 20, className = '' }) {
+  const glyph = PATHS[name]
+  if (!glyph) return null
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {glyph}
+    </svg>
+  )
+}

--- a/frontend/src/components/ui.jsx
+++ b/frontend/src/components/ui.jsx
@@ -1,3 +1,5 @@
+import Icon from './icons.jsx'
+
 export function MetricCard({ color, count, label, icon, helper }) {
   return (
     <article className={`metric-card ${color}`}>
@@ -7,6 +9,22 @@ export function MetricCard({ color, count, label, icon, helper }) {
         {helper ? <span>{helper}</span> : null}
       </div>
       <span className="metric-icon">{icon}</span>
+    </article>
+  )
+}
+
+// Clean SaaS-style stat tile used across the admin dashboard.
+export function StatTile({ tone = 'blue', icon, value, label, helper }) {
+  return (
+    <article className={`stat-tile tone-${tone}`}>
+      <div className="stat-tile-head">
+        <span className="stat-chip">
+          <Icon name={icon} size={18} />
+        </span>
+        {helper ? <span className="stat-helper">{helper}</span> : null}
+      </div>
+      <strong className="stat-value">{value}</strong>
+      <span className="stat-label">{label}</span>
     </article>
   )
 }


### PR DESCRIPTION
## Summary
Reworks the admin experience into a professional SaaS-style dashboard. The student portal is intentionally untouched.

- **AdminShell** — dark, collapsible sidebar (icon nav + user/logout footer) and a sticky topbar with a per-section title/subtitle, refresh, and admin pill; off-canvas with a scrim on mobile.
- **Cleaner content** — removed the stock-photo welcome banner and the redundant "Quick Actions" panel; replaced the saturated gradient metric cards with clean **StatTile**s (tinted icon chip, big value, label, helper). Panels, tables, and form inputs refined and unified — all scoped under `.admin-shell`.
- **Icons** — small inline SVG set, no external/CDN dependencies (CSP-safe).
- **Analytics** tab reuses the StatTile system.

## Scope / safety
- All new styling is namespaced under `.admin-shell`; the student portal still uses the original `Topbar` + `MetricCard` and is visually unchanged.

## Verification
- Frontend: lint clean, `npm run build` succeeds. (Not screenshotted — the admin view needs the full stack + an admin login to render.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)