### PR TITLE
fix(docker): add .dockerignore files to fix frontend image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Build context hygiene for the single-image (repo-root) Docker build.
+# Host build artifacts must never overwrite the image's platform-correct deps.
+
+# Node
+**/node_modules
+frontend/dist
+frontend/.vite
+
+# Python
+**/__pycache__
+**/*.py[cod]
+venv
+.venv
+backend/.testvenv
+backend/**/*.sqlite
+backend/**/*.sqlite3
+*.egg-info
+
+# VCS / editor / OS
+.git
+.gitignore
+.github
+**/.DS_Store
+.vscode
+.idea
+
+# Local env and docs
+.env
+.env.*
+!.env.example
+*.md

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,19 @@
+# Keep host-only artifacts out of the backend image build context.
+__pycache__
+**/__pycache__
+*.py[cod]
+venv
+.venv
+.testvenv
+*.sqlite
+*.sqlite3
+.alembic_*.sqlite
+.pytest_cache
+.ruff_cache
+.coverage
+.git
+.gitignore
+**/.DS_Store
+.env
+.env.*
+!.env.example

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+# Never copy host build artifacts into the image — the image installs its own
+# platform-correct dependencies via `npm ci`. Copying a host node_modules (e.g.
+# macOS-built esbuild/rollup binaries) over them breaks `npm run build`.
+node_modules
+dist
+.vite
+npm-debug.log*
+.DS_Store
+.git
+.gitignore
+Dockerfile
+.dockerignore


### PR DESCRIPTION
## Problem
`docker compose up --build` failed at the frontend image's `npm run build` with exit code 1.

The frontend Dockerfile runs `npm ci` and then `COPY . .`, but there was **no `.dockerignore`**, so the host's `node_modules` (macOS `darwin-arm64` esbuild/rollup binaries) got copied over the image's freshly installed Linux deps — and vite failed loading a wrong-platform native binary. It surfaced now because a local `npm ci` had created `frontend/node_modules` on disk.

## Fix
Add `.dockerignore` at:
- **`frontend/`** — compose frontend build context
- repo **root** — single-image build context (`COPY frontend/ ./`, `COPY backend/ ./`)
- **`backend/`** — compose backend build context

They exclude `node_modules`, build artifacts (`dist`, `.vite`), Python caches/venvs, `*.sqlite`, and local env files from the build context.

## Verification
- `docker compose build frontend` now **succeeds** end-to-end (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)