### PR TITLE
Fix login/register 404 (double /api prefix) + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ proxy, and a Vite React frontend.
   Google Identity Services sign-in.
 - Enforced password strength, self-service password reset, and sign-out that
   revokes existing sessions everywhere.
-- Role-based admin and student dashboards.
-- Admin student management, including single-student creation and CSV-style
-  bulk upload.
-- Admin exam authoring, including bulk JSON exam upload and MCQ question banks.
+- Role-based admin and student dashboards, with a professional admin console
+  (collapsible sidebar navigation, sticky topbar, and stat tiles).
+- Admin student management, including a searchable student table with delete,
+  single-student creation, and CSV-style bulk upload.
+- Admin exam authoring with live validation, per-question editing, bulk JSON
+  exam upload, and MCQ question banks.
 - Exam assignment workflow with optional SMTP email notifications.
 - Database-backed worker queue for assignment emails and submitted-attempt
   reports.
@@ -56,6 +58,19 @@ Worker
   |-- SMTP provider, when configured
 ```
 
+The React frontend is organised into small, focused modules rather than a single
+file:
+
+```text
+frontend/src/
+  lib/         API client and shared constants
+  hooks/       useAdminPortal, useStudentPortal, useExamGuard
+  components/
+    admin/     AdminShell + Overview, Analytics, ManageUsers, ExamBuilder, ...
+    student/   StudentDashboard, ExamRunner
+    ui.jsx     shared presentational primitives (StatTile, MetricCard, ...)
+```
+
 ## Tech Stack
 
 | Layer           | Technology                                                     |
@@ -63,7 +78,7 @@ Worker
 | Backend API     | FastAPI, SQLAlchemy, Pydantic, Uvicorn, Gunicorn               |
 | Database        | PostgreSQL 16                                                  |
 | Background jobs | Database-backed queue worker                                   |
-| Frontend        | React, Vite                                                    |
+| Frontend        | React 19, Vite (modular components + hooks)                     |
 | Edge            | Nginx reverse proxy                                            |
 | Auth            | Password login, role checks, optional Google Identity Services |
 | Deployment      | Docker, Docker Compose, optional Certbot/Let's Encrypt         |

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,13 +1,31 @@
 import { API_BASE_URL } from './constants.js'
 
 /**
+ * Join the configured base with a request path without duplicating a shared
+ * prefix. Request paths already start with `/api/v1/...`, so:
+ *   base ""                       + "/api/v1/x" -> "/api/v1/x"        (same-origin)
+ *   base "http://localhost:8001"  + "/api/v1/x" -> "http://localhost:8001/api/v1/x"
+ *   base "/api"                   + "/api/v1/x" -> "/api/v1/x"        (no double /api)
+ * The last case guards against a stale `VITE_API_BASE_URL=/api`, which would
+ * otherwise produce `/api/api/v1/...` and 404.
+ */
+export function buildUrl(base, path) {
+  if (!base) return path
+  const trimmed = base.replace(/\/+$/, '')
+  if (trimmed.startsWith('/') && path.startsWith(`${trimmed}/`)) {
+    return path
+  }
+  return `${trimmed}${path}`
+}
+
+/**
  * Build an API client bound to a token getter. The getter is read on every
  * request so the client always sends the current session's bearer token.
  */
 export function createApiClient(getToken) {
   return async function apiRequest(path, options = {}) {
     const token = typeof getToken === 'function' ? getToken() : getToken
-    const response = await fetch(`${API_BASE_URL}${path}`, {
+    const response = await fetch(buildUrl(API_BASE_URL, path), {
       ...options,
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Fix: login/register "Not Found"
Frontend call paths already start with `/api/v1/…`, but the production build sets `VITE_API_BASE_URL=/api`, so the client requested `/api/api/v1/auth/login` → nginx/FastAPI **404 `{"detail":"Not Found"}`**.

`buildUrl()` now avoids duplicating a shared leading prefix, producing the correct single-`/api` URL whether the base is empty (same-origin), a full host (dev), or a stale `/api`.

**Verified against the running stack:** `/api/api/v1/auth/login` → 404 (repro); `/api/v1/auth/login` → 201 register / 422 validation; rebuilt frontend image serves the fixed bundle.

## Docs
README refreshed for the redesigned admin console (sidebar layout) and the modular frontend structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)